### PR TITLE
Run tests using 'SiteTree' class, not 'Page' class

### DIFF
--- a/tests/WorkflowEmbargoExpiryTest.php
+++ b/tests/WorkflowEmbargoExpiryTest.php
@@ -4,308 +4,318 @@
  * @author marcus@silverstripe.com.au
  * @license BSD License http://silverstripe.org/bsd-license/
  */
-class WorkflowEmbargoExpiryTest extends SapphireTest {
+class WorkflowEmbargoExpiryTest extends SapphireTest
+{
 
-	public function setUp() {
-		parent::setUp();
+    public function setUp()
+    {
+        parent::setUp();
 
-		SS_Datetime::set_mock_now('2014-01-05 12:00:00');
+        SS_Datetime::set_mock_now('2014-01-05 12:00:00');
 
 
         // Prevent failure if queuedjobs module isn't installed.
         if (!class_exists('AbstractQueuedJob', false)) {
             $this->markTestSkipped("This test requires queuedjobs");
         }
-	}
-
-	public function tearDown() {
-		SS_Datetime::clear_mock_now();
-		parent::tearDown();
-	}
-
-	/**
-	 * @var array
-	 */
-	protected $requiredExtensions = array(
-		'SiteTree' => array(
-			'WorkflowEmbargoExpiryExtension',
-			'Versioned',
-		)
-	);
-
-	/**
-	 * @var array
-	 */
-	protected $illegalExtensions = array(
-		'SiteTree' => array(
-			"Translatable",
-		)
-	);
-
-	public function __construct() {
-		if(!class_exists('AbstractQueuedJob')) {
-			$this->skipTest = true;
-		}
-		parent::__construct();
-	}
-
-	public function testFutureDatesJobs() {
-		$page = new Page();
-
-		$page->PublishOnDate = '2020-01-01 00:00:00';
-		$page->UnPublishOnDate = '2020-01-01 01:00:00';
-
-		// Two writes are necessary for this to work on new objects
-		$page->write();
-		$page->write();
-
-		$this->assertTrue($page->PublishJobID > 0);
-		$this->assertTrue($page->UnPublishJobID > 0);
-
-		// Check date ranges
-		$now = strtotime(SS_Datetime::now()->getValue());
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unPublish = strtotime($page->UnPublishJob()->StartAfter);
-
-		$this->assertGreaterThan($now, $publish);
-		$this->assertGreaterThan($now, $unPublish);
-		$this->assertGreaterThan($publish, $unPublish);
-	}
-
-	public function testDesiredRemovesJobs() {
-		$page = new Page();
-
-		$page->PublishOnDate = '2020-01-01 00:00:00';
-		$page->UnPublishOnDate = '2020-01-01 01:00:00';
-
-		// Two writes are necessary for this to work on new objects
-		$page->write();
-		$page->write();
-
-		$this->assertTrue($page->PublishJobID > 0);
-		$this->assertTrue($page->UnPublishJobID > 0);
-
-		// Check date ranges
-		$now = strtotime(SS_Datetime::now()->getValue());
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unPublish = strtotime($page->UnPublishJob()->StartAfter);
-
-		$this->assertGreaterThan($now, $publish);
-		$this->assertGreaterThan($now, $unPublish);
-		$this->assertGreaterThan($publish, $unPublish);
-
-		$page->DesiredPublishDate = '2020-02-01 00:00:00';
-		$page->DesiredUnPublishDate = '2020-02-01 02:00:00';
-
-		$page->write();
-
-		$this->assertTrue($page->PublishJobID == 0);
-		$this->assertTrue($page->UnPublishJobID == 0);
-	}
-
-	public function testPublishActionWithFutureDates() {
-		$action = new PublishItemWorkflowAction();
-		$instance = new WorkflowInstance();
-
-		$page = new Page();
-		$page->Title = 'stuff';
-		$page->DesiredPublishDate = '2020-02-01 00:00:00';
-		$page->DesiredUnPublishDate = '2020-02-01 02:00:00';
-
-		$page->write();
-
-		$instance->TargetClass = $page->ClassName;
-		$instance->TargetID = $page->ID;
-
-		$action->execute($instance);
-
-		$page = DataObject::get_by_id('Page', $page->ID);
-		$this->assertTrue($page->PublishJobID > 0);
-		$this->assertTrue($page->UnPublishJobID > 0);
-
-		// Check date ranges
-		$now = strtotime(SS_Datetime::now()->getValue());
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unPublish = strtotime($page->UnPublishJob()->StartAfter);
-
-		$this->assertGreaterThan($now, $publish);
-		$this->assertGreaterThan($now, $unPublish);
-		$this->assertGreaterThan($publish, $unPublish);
-	}
-
-	/**
-	 * Test that a page with a past publish date creates the correct jobs
-	 */
-	public function testPastPublishThenUnpublish() {
-		$page = new Page();
-		$page->Title = 'My Page';
-		$page->write();
-
-		// No publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Set a past publish date
-		$page->PublishOnDate = '2010-01-01 00:00:00';
-		$page->write();
-
-		// We should still have a job to publish this page, but not unpublish
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Check that this job is set for immediate run
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$this->assertEmpty($publish);
-
-		// Now add an expiry date in the past, but after the current publish job,
-		// and ensure that this correctly overrides the open publish request
-		$page->UnPublishOnDate = '2010-01-02 00:00:00';
-		$page->write();
-
-		// Now we should have an unpublish job, but the publish job is noticably absent
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this unpublish job is set for immediate run
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($unpublish);
-
-		// Now add an expiry date in the future, and ensure that we get the correct combination of
-		// publish and unpublish jobs
-		$page->UnPublishOnDate = '2015-01-01 12:00:00';
-		$page->write();
-
-		// Both jobs exist
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this unpublish job is set for immediate run and the unpublish for future
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($publish); // for immediate run
-		$this->assertGreaterThan(strtotime(SS_Datetime::now()->getValue()), $unpublish); // for later run
-	}
-
-	/**
-	 * Test that a page with a past unpublish date creates the correct jobs
-	 */
-	public function testPastUnPublishThenPublish() {
-		$page = new Page();
-		$page->Title = 'My Page';
-		$page->write();
-
-		// No publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Set a past unpublish date
-		$page->UnPublishOnDate = '2010-01-01 00:00:00';
-		$page->write();
-
-		// We should still have a job to unpublish this page, but not publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this job is set for immediate run
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($unpublish);
-
-		// Now add an publish date in the past, but after the unpublish job,
-		// and ensure that this correctly overrides the open unpublish request
-		$page->PublishOnDate = '2010-01-02 00:00:00';
-		$page->write();
-
-		// Now we should have an publish job, but the unpublish job is noticably absent
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Check that this publish job is set for immediate run
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$this->assertEmpty($publish);
-
-		// Now add a publish date in the future, and ensure that we get the correct combination of
-		// publish and unpublish jobs
-		$page->PublishOnDate = '2015-01-01 12:00:00';
-		$page->write();
-
-		// Both jobs exist
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertNotEmpty($page->UnPublishJobID);
-
-		// Check that this unpublish job is set for immediate run and the unpublish for future
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$unpublish = strtotime($page->UnPublishJob()->StartAfter);
-		$this->assertEmpty($unpublish); // for immediate run
-		$this->assertGreaterThan(strtotime(SS_Datetime::now()->getValue()), $publish); // for later run
-	}
-
-	public function testPastPublishWithWorkflowInEffect() {
-		$definition = $this->createDefinition();
-
-		$page = new Page();
-		$page->Title = 'My page';
-		$page->WorkflowDefinitionID = $definition->ID;
-		$page->write();
-
-		// No publish
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Set a past publish date
-		$page->DesiredPublishDate = '2010-01-01 00:00:00';
-		$page->write();
-
-		// Workflow is in effect. No jobs have been created yet as it's not approved.
-		$this->assertEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Advance the workflow so we can see what happens
-		$instance = new WorkflowInstance();
-		$instance->beginWorkflow($definition, $page);
-		$instance->execute();
-
-		// execute the "publish" workflow action
-		$action = new PublishItemWorkflowAction();
-		$action->execute($instance);
-
-		// re-fetch the Page again.
-		$page = Page::get()->byId($page->ID);
-
-		// We now have a PublishOnDate field set
-		$this->assertEquals('2010-01-01 00:00:00', $page->PublishOnDate);
-		$this->assertEmpty($page->DesiredPublishDate);
-
-		// Publish job has been setup
-		$this->assertNotEmpty($page->PublishJobID);
-		$this->assertEmpty($page->UnPublishJobID);
-
-		// Check that this publish job is set for immediate run
-		$publish = strtotime($page->PublishJob()->StartAfter);
-		$this->assertEmpty($publish);
-	}
-
-	protected function createDefinition() {
-		$definition = new WorkflowDefinition();
-		$definition->Title = 'Dummy Workflow Definition';
-		$definition->write();
-
-		$stepOne = new WorkflowAction();
-		$stepOne->Title = 'Step One';
-		$stepOne->WorkflowDefID = $definition->ID;
-		$stepOne->write();
-
-		$stepTwo = new WorkflowAction();
-		$stepTwo->Title = 'Step Two';
-		$stepTwo->WorkflowDefID = $definition->ID;
-		$stepTwo->write();
-
-		$transitionOne = new WorkflowTransition();
-		$transitionOne->Title = 'Step One T1';
-		$transitionOne->ActionID = $stepOne->ID;
-		$transitionOne->NextActionID = $stepTwo->ID;
-		$transitionOne->write();
-
-		return $definition;
-	}
-
+    }
+
+    public function tearDown()
+    {
+        SS_Datetime::clear_mock_now();
+        parent::tearDown();
+    }
+
+    /**
+     * @var array
+     */
+    protected $requiredExtensions = array(
+        'SiteTree' => array(
+            'WorkflowEmbargoExpiryExtension',
+            'Versioned',
+        )
+    );
+
+    /**
+     * @var array
+     */
+    protected $illegalExtensions = array(
+        'SiteTree' => array(
+            "Translatable",
+        )
+    );
+
+    public function __construct()
+    {
+        if (!class_exists('AbstractQueuedJob')) {
+            $this->skipTest = true;
+        }
+        parent::__construct();
+    }
+
+    public function testFutureDatesJobs()
+    {
+        $page = new SiteTree();
+
+        $page->PublishOnDate = '2020-01-01 00:00:00';
+        $page->UnPublishOnDate = '2020-01-01 01:00:00';
+
+        // Two writes are necessary for this to work on new objects
+        $page->write();
+        $page->write();
+
+        $this->assertTrue($page->PublishJobID > 0);
+        $this->assertTrue($page->UnPublishJobID > 0);
+
+        // Check date ranges
+        $now = strtotime(SS_Datetime::now()->getValue());
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unPublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertGreaterThan($now, $publish);
+        $this->assertGreaterThan($now, $unPublish);
+        $this->assertGreaterThan($publish, $unPublish);
+    }
+
+    public function testDesiredRemovesJobs()
+    {
+        $page = new SiteTree();
+
+        $page->PublishOnDate = '2020-01-01 00:00:00';
+        $page->UnPublishOnDate = '2020-01-01 01:00:00';
+
+        // Two writes are necessary for this to work on new objects
+        $page->write();
+        $page->write();
+
+        $this->assertTrue($page->PublishJobID > 0);
+        $this->assertTrue($page->UnPublishJobID > 0);
+
+        // Check date ranges
+        $now = strtotime(SS_Datetime::now()->getValue());
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unPublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertGreaterThan($now, $publish);
+        $this->assertGreaterThan($now, $unPublish);
+        $this->assertGreaterThan($publish, $unPublish);
+
+        $page->DesiredPublishDate = '2020-02-01 00:00:00';
+        $page->DesiredUnPublishDate = '2020-02-01 02:00:00';
+
+        $page->write();
+
+        $this->assertTrue($page->PublishJobID == 0);
+        $this->assertTrue($page->UnPublishJobID == 0);
+    }
+
+    public function testPublishActionWithFutureDates()
+    {
+        $action = new PublishItemWorkflowAction();
+        $instance = new WorkflowInstance();
+
+        $page = new SiteTree();
+        $page->Title = 'stuff';
+        $page->DesiredPublishDate = '2020-02-01 00:00:00';
+        $page->DesiredUnPublishDate = '2020-02-01 02:00:00';
+
+        $page->write();
+
+        $instance->TargetClass = $page->ClassName;
+        $instance->TargetID = $page->ID;
+
+        $action->execute($instance);
+
+        $page = DataObject::get_by_id('SiteTree', $page->ID);
+        $this->assertTrue($page->PublishJobID > 0);
+        $this->assertTrue($page->UnPublishJobID > 0);
+
+        // Check date ranges
+        $now = strtotime(SS_Datetime::now()->getValue());
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unPublish = strtotime($page->UnPublishJob()->StartAfter);
+
+        $this->assertGreaterThan($now, $publish);
+        $this->assertGreaterThan($now, $unPublish);
+        $this->assertGreaterThan($publish, $unPublish);
+    }
+
+    /**
+     * Test that a page with a past publish date creates the correct jobs
+     */
+    public function testPastPublishThenUnpublish()
+    {
+        $page = new SiteTree();
+        $page->Title = 'My Page';
+        $page->write();
+
+        // No publish
+        $this->assertEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Set a past publish date
+        $page->PublishOnDate = '2010-01-01 00:00:00';
+        $page->write();
+
+        // We should still have a job to publish this page, but not unpublish
+        $this->assertNotEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Check that this job is set for immediate run
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $this->assertEmpty($publish);
+
+        // Now add an expiry date in the past, but after the current publish job,
+        // and ensure that this correctly overrides the open publish request
+        $page->UnPublishOnDate = '2010-01-02 00:00:00';
+        $page->write();
+
+        // Now we should have an unpublish job, but the publish job is noticably absent
+        $this->assertEmpty($page->PublishJobID);
+        $this->assertNotEmpty($page->UnPublishJobID);
+
+        // Check that this unpublish job is set for immediate run
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+        $this->assertEmpty($unpublish);
+
+        // Now add an expiry date in the future, and ensure that we get the correct combination of
+        // publish and unpublish jobs
+        $page->UnPublishOnDate = '2015-01-01 12:00:00';
+        $page->write();
+
+        // Both jobs exist
+        $this->assertNotEmpty($page->PublishJobID);
+        $this->assertNotEmpty($page->UnPublishJobID);
+
+        // Check that this unpublish job is set for immediate run and the unpublish for future
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+        $this->assertEmpty($publish); // for immediate run
+        $this->assertGreaterThan(strtotime(SS_Datetime::now()->getValue()), $unpublish); // for later run
+    }
+
+    /**
+     * Test that a page with a past unpublish date creates the correct jobs
+     */
+    public function testPastUnPublishThenPublish()
+    {
+        $page = new SiteTree();
+        $page->Title = 'My Page';
+        $page->write();
+
+        // No publish
+        $this->assertEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Set a past unpublish date
+        $page->UnPublishOnDate = '2010-01-01 00:00:00';
+        $page->write();
+
+        // We should still have a job to unpublish this page, but not publish
+        $this->assertEmpty($page->PublishJobID);
+        $this->assertNotEmpty($page->UnPublishJobID);
+
+        // Check that this job is set for immediate run
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+        $this->assertEmpty($unpublish);
+
+        // Now add an publish date in the past, but after the unpublish job,
+        // and ensure that this correctly overrides the open unpublish request
+        $page->PublishOnDate = '2010-01-02 00:00:00';
+        $page->write();
+
+        // Now we should have an publish job, but the unpublish job is noticably absent
+        $this->assertNotEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Check that this publish job is set for immediate run
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $this->assertEmpty($publish);
+
+        // Now add a publish date in the future, and ensure that we get the correct combination of
+        // publish and unpublish jobs
+        $page->PublishOnDate = '2015-01-01 12:00:00';
+        $page->write();
+
+        // Both jobs exist
+        $this->assertNotEmpty($page->PublishJobID);
+        $this->assertNotEmpty($page->UnPublishJobID);
+
+        // Check that this unpublish job is set for immediate run and the unpublish for future
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $unpublish = strtotime($page->UnPublishJob()->StartAfter);
+        $this->assertEmpty($unpublish); // for immediate run
+        $this->assertGreaterThan(strtotime(SS_Datetime::now()->getValue()), $publish); // for later run
+    }
+
+    public function testPastPublishWithWorkflowInEffect()
+    {
+        $definition = $this->createDefinition();
+
+        $page = new SiteTree();
+        $page->Title = 'My page';
+        $page->WorkflowDefinitionID = $definition->ID;
+        $page->write();
+
+        // No publish
+        $this->assertEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Set a past publish date
+        $page->DesiredPublishDate = '2010-01-01 00:00:00';
+        $page->write();
+
+        // Workflow is in effect. No jobs have been created yet as it's not approved.
+        $this->assertEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Advance the workflow so we can see what happens
+        $instance = new WorkflowInstance();
+        $instance->beginWorkflow($definition, $page);
+        $instance->execute();
+
+        // execute the "publish" workflow action
+        $action = new PublishItemWorkflowAction();
+        $action->execute($instance);
+
+        // re-fetch the Page again.
+        $page = SiteTree::get()->byId($page->ID);
+
+        // We now have a PublishOnDate field set
+        $this->assertEquals('2010-01-01 00:00:00', $page->PublishOnDate);
+        $this->assertEmpty($page->DesiredPublishDate);
+
+        // Publish job has been setup
+        $this->assertNotEmpty($page->PublishJobID);
+        $this->assertEmpty($page->UnPublishJobID);
+
+        // Check that this publish job is set for immediate run
+        $publish = strtotime($page->PublishJob()->StartAfter);
+        $this->assertEmpty($publish);
+    }
+
+    protected function createDefinition()
+    {
+        $definition = new WorkflowDefinition();
+        $definition->Title = 'Dummy Workflow Definition';
+        $definition->write();
+
+        $stepOne = new WorkflowAction();
+        $stepOne->Title = 'Step One';
+        $stepOne->WorkflowDefID = $definition->ID;
+        $stepOne->write();
+
+        $stepTwo = new WorkflowAction();
+        $stepTwo->Title = 'Step Two';
+        $stepTwo->WorkflowDefID = $definition->ID;
+        $stepTwo->write();
+
+        $transitionOne = new WorkflowTransition();
+        $transitionOne->Title = 'Step One T1';
+        $transitionOne->ActionID = $stepOne->ID;
+        $transitionOne->NextActionID = $stepTwo->ID;
+        $transitionOne->write();
+
+        return $definition;
+    }
 }

--- a/tests/WorkflowEngineTest.php
+++ b/tests/WorkflowEngineTest.php
@@ -7,287 +7,304 @@
  * @package    advancedworkflow
  * @subpackage tests
  */
-class WorkflowEngineTest extends SapphireTest {
-
-	public static $fixture_file = 'advancedworkflow/tests/workflowinstancetargets.yml';
-
-	public function testCreateWorkflowInstance() {
-
-		$definition = new WorkflowDefinition();
-		$definition->Title = "Create Workflow Instance";
-		$definition->write();
-
-		$stepOne = new WorkflowAction();
-		$stepOne->Title = "Step One";
-		$stepOne->WorkflowDefID = $definition->ID;
-		$stepOne->write();
-
-		$stepTwo = new WorkflowAction();
-		$stepTwo->Title = "Step Two";
-		$stepTwo->WorkflowDefID = $definition->ID;
-		$stepTwo->write();
-
-		$transitionOne = new WorkflowTransition();
-		$transitionOne->Title = 'Step One T1';
-		$transitionOne->ActionID = $stepOne->ID;
-		$transitionOne->NextActionID = $stepTwo->ID;
-		$transitionOne->write();
-
-		$instance = new WorkflowInstance();
-		$instance->write();
-
-		$instance->beginWorkflow($definition);
-
-		$actions = $definition->Actions();
-		$this->assertEquals(2, $actions->Count());
-
-		$transitions = $actions->find('Title', 'Step One')->Transitions();
-		$this->assertEquals(1, $transitions->Count());
-	}
-
-	public function testExecuteImmediateWorkflow() {
-		$def = $this->createDefinition();
-
-		$actions = $def->Actions();
-		$firstAction = $def->getInitialAction();
-		$this->assertEquals('Step One', $firstAction->Title);
-
-		$instance = new WorkflowInstance();
-		$instance->beginWorkflow($def);
-		$this->assertTrue($instance->CurrentActionID > 0);
-
-		$instance->execute();
-
-		// the instance should be complete, and have two finished workflow action
-		// instances.
-		$actions = $instance->Actions();
-		$this->assertEquals(2, $actions->Count());
-
-		foreach($actions as $action) {
-			$this->assertTrue((bool) $action->Finished);
-		}
-	}
-
-	/**
-	 * Ensure WorkflowInstance returns expected values for a Published target object.
-	 */
-	public function testInstanceGetTargetPublished() {
-		$def = $this->createDefinition();
-		$target = $this->objFromFixture('SiteTree', 'published-object');
-		$target->doPublish();
-
-		$instance = $this->objFromFixture('WorkflowInstance', 'target-is-published');
-		$instance->beginWorkflow($def);
-		$instance->execute();
-
-		$this->assertTrue($target->isPublished());
-		$this->assertEquals($target->ID, $instance->getTarget()->ID);
-		$this->assertEquals($target->Title, $instance->getTarget()->Title);
-	}
-
-	/**
-	 * Ensure WorkflowInstance returns expected values for a Draft target object.
-	 */
-	public function testInstanceGetTargetDraft() {
-		$def = $this->createDefinition();
-		$target = $this->objFromFixture('SiteTree', 'draft-object');
-
-		$instance = $this->objFromFixture('WorkflowInstance', 'target-is-draft');
-		$instance->beginWorkflow($def);
-		$instance->execute();
-
-		$this->assertFalse($target->isPublished());
-		$this->assertEquals($target->ID, $instance->getTarget()->ID);
-		$this->assertEquals($target->Title, $instance->getTarget()->Title);
-	}
-
-	public function testPublishAction() {
-		$this->logInWithPermission();
-
-		$action = new PublishItemWorkflowAction;
-		$instance = new WorkflowInstance();
-
-		$page = new Page();
-		$page->Title = 'stuff';
-		$page->write();
-
-		$instance->TargetClass = 'Page';
-		$instance->TargetID = $page->ID;
-
-		$this->assertFalse($page->isPublished());
-
-		$action->execute($instance);
-
-		$page = DataObject::get_by_id('Page', $page->ID);
-		$this->assertTrue($page->isPublished());
-
-	}
-
-	public function testCreateDefinitionWithEmptyTitle() {
-		$definition = new WorkflowDefinition();
-		$definition->Title = "";
-		$definition->write();
-		$this->assertContains('My Workflow',$definition->Title,'Workflow created without title is assigned a default title.');
-	}
-
-	protected function createDefinition() {
-		$definition = new WorkflowDefinition();
-		$definition->Title = "Dummy Workflow Definition";
-		$definition->write();
-
-		$stepOne = new WorkflowAction();
-		$stepOne->Title = "Step One";
-		$stepOne->WorkflowDefID = $definition->ID;
-		$stepOne->write();
-
-		$stepTwo = new WorkflowAction();
-		$stepTwo->Title = "Step Two";
-		$stepTwo->WorkflowDefID = $definition->ID;
-		$stepTwo->write();
-
-		$transitionOne = new WorkflowTransition();
-		$transitionOne->Title = 'Step One T1';
-		$transitionOne->ActionID = $stepOne->ID;
-		$transitionOne->NextActionID = $stepTwo->ID;
-		$transitionOne->write();
-
-		return $definition;
-	}
-
-
-	public function testCreateFromTemplate() {
-		$structure = array(
-			'First step'	=> array(
-				'type'		=> 'AssignUsersToWorkflowAction',
-				'transitions'	=> array(
-					'second'	=> 'Second step'
-				)
-			),
-			'Second step'	=> array(
-				'type'		=> 'NotifyUsersWorkflowAction',
-				'transitions'	=> array(
-					'Approve'	=> 'Third step'
-				)
-			),
-		);
-
-		$template = new WorkflowTemplate('Test');
-
-		$template->setStructure($structure);
-
-		$actions = $template->createRelations();
-
-		$this->assertEquals(2, count($actions));
-		$this->assertTrue(isset($actions['First step']));
-		$this->assertTrue(isset($actions['Second step']));
-
-		$this->assertTrue($actions['First step']->exists());
-
-		$transitions = $actions['First step']->Transitions();
-
-		$this->assertTrue($transitions->count() == 1);
-
-
-	}
-
-	/**
-	 * Tests whether if user(s) are able to delete a workflow, dependent on permissions.
-	 */
-	public function testCanDeleteWorkflow() {
-		// Create a definition
-		$def = $this->createDefinition();
-
-		// Test a user with lame permissions
-		$memberID = $this->logInWithPermission('SITETREE_VIEW_ALL');
-		$member = DataObject::get_by_id('Member', $memberID);
-		$this->assertFalse($def->canCreate($member));
-
-		// Test a user with good permissions
-		$memberID = $this->logInWithPermission('CREATE_WORKFLOW');
-		$member = DataObject::get_by_id('Member', $memberID);
-		$this->assertTrue($def->canCreate($member));
-	}
-
-	/**
-	 * For a context around this test, see: https://github.com/silverstripe-australia/advancedworkflow/issues/141
-	 *
-	 *	1). Create a workflow definition
-	 *	2). Step the content into that workflow
-	 *	3). Delete the workflow
-	 *	4). Check that the content:
-	 *		i). Has no remaining related actions
-	 *		ii). Can be re-assigned a new Workflow
-	 *	5). Check that the object under workflow, maintains its status (Draft, Published etc)
-	 */
-	public function testDeleteWorkflowTargetStillWorks() {
-		// 1). Create a workflow definition
-		$def = $this->createDefinition();
-		$page = Page::create();
-		$page->Title = 'dummy test';
-		$page->WorkflowDefinitionID = $def->ID;	// Normally done via CMS
-		Versioned::set_stage(Versioned::DRAFT);
-		$page->write();
-
-		// Check $page is in draft, pre-deletion
-		$status = ($page->getIsAddedToStage() && !$page->getExistsOnLive());
-		$this->assertTrue($status);
-
-		// 2). Step the content into that workflow
-		$instance = new WorkflowInstance();
-		$instance->beginWorkflow($def, $page);
-		$instance->execute();
-
-		// Check the content is assigned
-		$testPage = DataObject::get_by_id('Page', $page->ID);
-		$this->assertEquals($instance->TargetID, $testPage->ID);
-
-		// 3). Delete the workflow
-		$def->delete();
-
-		// Check $testPage is _still_ in draft, post-deletion
-		$status = ($testPage->getIsAddedToStage() && !$testPage->getExistsOnLive());
-		$this->assertTrue($status);
-
-		/*
-		 * 4). i). Check that the content: Has no remaining related actions
-		 * Note: WorkflowApplicable::WorkflowDefinitionID does _not_ get updated until assigned a new workflow
-		 * so we can use it to check that all related actions are gone
-		 */
-		$defID = $testPage->WorkflowDefinitionID;
-		$this->assertEquals(0, DataObject::get('WorkflowAction')->filter('WorkflowDefID', $defID)->count());
-
-		/*
-		 * 4). ii). Check that the content: Can be re-assigned a new Workflow Definition
-		 */
-		$newDef = $this->createDefinition();
-		$testPage->WorkflowDefinitionID = $newDef->ID;	// Normally done via CMS
-		$instance = new WorkflowInstance();
-		$instance->beginWorkflow($newDef, $testPage);
-		$instance->execute();
-
-		// Check the content is assigned to the new Workflow Definition correctly
-		$this->assertEquals($newDef->ID, $testPage->WorkflowDefinitionID);
-		$this->assertEquals($newDef->Actions()->count(), DataObject::get('WorkflowAction')->filter('WorkflowDefID', $newDef->ID)->count());
-
-		// 5). Check that the object under workflow, maintains its status
-		$newDef2 = $this->createDefinition();
-
-		// Login so SiteTree::canPublish() returns true
-		$testPage->WorkflowDefinitionID = $newDef2->ID;	// Normally done via CMS
-		$this->logInWithPermission();
-		$testPage->doPublish();
-
-		// Check $testPage is published, pre-deletion (getStatusFlags() returns empty array)
-		$this->assertTrue($testPage->getExistsOnLive());
-
-		$instance = new WorkflowInstance();
-		$instance->beginWorkflow($newDef2, $testPage);
-		$instance->execute();
-
-		// Now delete the related WorkflowDefinition and ensure status is the same (i.e. so it's not 'modified' for example)
-		$newDef2->delete();
-
-		// Check $testPage is _still_ published, post-deletion (getStatusFlags() returns empty array)
-		$this->assertTrue($testPage->getExistsOnLive());
-	}
+class WorkflowEngineTest extends SapphireTest
+{
+
+    public static $fixture_file = 'advancedworkflow/tests/workflowinstancetargets.yml';
+
+    public function testCreateWorkflowInstance()
+    {
+
+        $definition = new WorkflowDefinition();
+        $definition->Title = "Create Workflow Instance";
+        $definition->write();
+
+        $stepOne = new WorkflowAction();
+        $stepOne->Title = "Step One";
+        $stepOne->WorkflowDefID = $definition->ID;
+        $stepOne->write();
+
+        $stepTwo = new WorkflowAction();
+        $stepTwo->Title = "Step Two";
+        $stepTwo->WorkflowDefID = $definition->ID;
+        $stepTwo->write();
+
+        $transitionOne = new WorkflowTransition();
+        $transitionOne->Title = 'Step One T1';
+        $transitionOne->ActionID = $stepOne->ID;
+        $transitionOne->NextActionID = $stepTwo->ID;
+        $transitionOne->write();
+
+        $instance = new WorkflowInstance();
+        $instance->write();
+
+        $instance->beginWorkflow($definition);
+
+        $actions = $definition->Actions();
+        $this->assertEquals(2, $actions->Count());
+
+        $transitions = $actions->find('Title', 'Step One')->Transitions();
+        $this->assertEquals(1, $transitions->Count());
+    }
+
+    public function testExecuteImmediateWorkflow()
+    {
+        $def = $this->createDefinition();
+
+        $actions = $def->Actions();
+        $firstAction = $def->getInitialAction();
+        $this->assertEquals('Step One', $firstAction->Title);
+
+        $instance = new WorkflowInstance();
+        $instance->beginWorkflow($def);
+        $this->assertTrue($instance->CurrentActionID > 0);
+
+        $instance->execute();
+
+        // the instance should be complete, and have two finished workflow action
+        // instances.
+        $actions = $instance->Actions();
+        $this->assertEquals(2, $actions->Count());
+
+        foreach ($actions as $action) {
+            $this->assertTrue((bool) $action->Finished);
+        }
+    }
+
+    /**
+     * Ensure WorkflowInstance returns expected values for a Published target object.
+     */
+    public function testInstanceGetTargetPublished()
+    {
+        $def = $this->createDefinition();
+        $target = $this->objFromFixture('SiteTree', 'published-object');
+        $target->doPublish();
+
+        $instance = $this->objFromFixture('WorkflowInstance', 'target-is-published');
+        $instance->beginWorkflow($def);
+        $instance->execute();
+
+        $this->assertTrue($target->isPublished());
+        $this->assertEquals($target->ID, $instance->getTarget()->ID);
+        $this->assertEquals($target->Title, $instance->getTarget()->Title);
+    }
+
+    /**
+     * Ensure WorkflowInstance returns expected values for a Draft target object.
+     */
+    public function testInstanceGetTargetDraft()
+    {
+        $def = $this->createDefinition();
+        $target = $this->objFromFixture('SiteTree', 'draft-object');
+
+        $instance = $this->objFromFixture('WorkflowInstance', 'target-is-draft');
+        $instance->beginWorkflow($def);
+        $instance->execute();
+
+        $this->assertFalse($target->isPublished());
+        $this->assertEquals($target->ID, $instance->getTarget()->ID);
+        $this->assertEquals($target->Title, $instance->getTarget()->Title);
+    }
+
+    public function testPublishAction()
+    {
+        $this->logInWithPermission();
+
+        $action = new PublishItemWorkflowAction;
+        $instance = new WorkflowInstance();
+
+        $page = new SiteTree();
+        $page->Title = 'stuff';
+        $page->write();
+
+        $instance->TargetClass = 'SiteTree';
+        $instance->TargetID = $page->ID;
+
+        $this->assertFalse($page->isPublished());
+
+        $action->execute($instance);
+
+        $page = DataObject::get_by_id('SiteTree', $page->ID);
+        $this->assertTrue($page->isPublished());
+
+    }
+
+    public function testCreateDefinitionWithEmptyTitle()
+    {
+        $definition = new WorkflowDefinition();
+        $definition->Title = "";
+        $definition->write();
+        $this->assertContains(
+            'My Workflow',
+            $definition->Title,
+            'Workflow created without title is assigned a default title.'
+        );
+    }
+
+    protected function createDefinition()
+    {
+        $definition = new WorkflowDefinition();
+        $definition->Title = "Dummy Workflow Definition";
+        $definition->write();
+
+        $stepOne = new WorkflowAction();
+        $stepOne->Title = "Step One";
+        $stepOne->WorkflowDefID = $definition->ID;
+        $stepOne->write();
+
+        $stepTwo = new WorkflowAction();
+        $stepTwo->Title = "Step Two";
+        $stepTwo->WorkflowDefID = $definition->ID;
+        $stepTwo->write();
+
+        $transitionOne = new WorkflowTransition();
+        $transitionOne->Title = 'Step One T1';
+        $transitionOne->ActionID = $stepOne->ID;
+        $transitionOne->NextActionID = $stepTwo->ID;
+        $transitionOne->write();
+
+        return $definition;
+    }
+
+
+    public function testCreateFromTemplate()
+    {
+        $structure = array(
+            'First step'    => array(
+                'type'      => 'AssignUsersToWorkflowAction',
+                'transitions'   => array(
+                    'second'    => 'Second step'
+                )
+            ),
+            'Second step'   => array(
+                'type'      => 'NotifyUsersWorkflowAction',
+                'transitions'  => array(
+                    'Approve'  => 'Third step'
+                )
+            ),
+        );
+
+        $template = new WorkflowTemplate('Test');
+
+        $template->setStructure($structure);
+
+        $actions = $template->createRelations();
+
+        $this->assertEquals(2, count($actions));
+        $this->assertTrue(isset($actions['First step']));
+        $this->assertTrue(isset($actions['Second step']));
+
+        $this->assertTrue($actions['First step']->exists());
+
+        $transitions = $actions['First step']->Transitions();
+
+        $this->assertTrue($transitions->count() == 1);
+    }
+
+    /**
+     * Tests whether if user(s) are able to delete a workflow, dependent on permissions.
+     */
+    public function testCanDeleteWorkflow()
+    {
+        // Create a definition
+        $def = $this->createDefinition();
+
+        // Test a user with lame permissions
+        $memberID = $this->logInWithPermission('SITETREE_VIEW_ALL');
+        $member = DataObject::get_by_id('Member', $memberID);
+        $this->assertFalse($def->canCreate($member));
+
+        // Test a user with good permissions
+        $memberID = $this->logInWithPermission('CREATE_WORKFLOW');
+        $member = DataObject::get_by_id('Member', $memberID);
+        $this->assertTrue($def->canCreate($member));
+    }
+
+    /**
+     * For a context around this test, see: https://github.com/silverstripe-australia/advancedworkflow/issues/141
+     *
+     *  1). Create a workflow definition
+     *  2). Step the content into that workflow
+     *  3). Delete the workflow
+     *  4). Check that the content:
+     *      i). Has no remaining related actions
+     *      ii). Can be re-assigned a new Workflow
+     *  5). Check that the object under workflow, maintains its status (Draft, Published etc)
+     */
+    public function testDeleteWorkflowTargetStillWorks()
+    {
+        // 1). Create a workflow definition
+        $def = $this->createDefinition();
+        $page = SiteTree::create();
+        $page->Title = 'dummy test';
+        $page->WorkflowDefinitionID = $def->ID; // Normally done via CMS
+        Versioned::set_stage(Versioned::DRAFT);
+        $page->write();
+
+        // Check $page is in draft, pre-deletion
+        $status = ($page->getIsAddedToStage() && !$page->getExistsOnLive());
+        $this->assertTrue($status);
+
+        // 2). Step the content into that workflow
+        $instance = new WorkflowInstance();
+        $instance->beginWorkflow($def, $page);
+        $instance->execute();
+
+        // Check the content is assigned
+        $testPage = DataObject::get_by_id('SiteTree', $page->ID);
+        $this->assertEquals($instance->TargetID, $testPage->ID);
+
+        // 3). Delete the workflow
+        $def->delete();
+
+        // Check $testPage is _still_ in draft, post-deletion
+        $status = ($testPage->getIsAddedToStage() && !$testPage->getExistsOnLive());
+        $this->assertTrue($status);
+
+        /*
+         * 4). i). Check that the content: Has no remaining related actions
+         * Note: WorkflowApplicable::WorkflowDefinitionID does _not_ get updated until assigned a new workflow
+         * so we can use it to check that all related actions are gone
+         */
+        $defID = $testPage->WorkflowDefinitionID;
+        $this->assertEquals(0, DataObject::get('WorkflowAction')->filter('WorkflowDefID', $defID)->count());
+
+        /*
+         * 4). ii). Check that the content: Can be re-assigned a new Workflow Definition
+         */
+        $newDef = $this->createDefinition();
+        $testPage->WorkflowDefinitionID = $newDef->ID;  // Normally done via CMS
+        $instance = new WorkflowInstance();
+        $instance->beginWorkflow($newDef, $testPage);
+        $instance->execute();
+
+        // Check the content is assigned to the new Workflow Definition correctly
+        $this->assertEquals($newDef->ID, $testPage->WorkflowDefinitionID);
+        $this->assertEquals(
+            $newDef->Actions()->count(),
+            DataObject::get('WorkflowAction')->filter('WorkflowDefID', $newDef->ID)->count()
+        );
+
+        // 5). Check that the object under workflow, maintains its status
+        $newDef2 = $this->createDefinition();
+
+        // Login so SiteTree::canPublish() returns true
+        $testPage->WorkflowDefinitionID = $newDef2->ID; // Normally done via CMS
+        $this->logInWithPermission();
+        $testPage->doPublish();
+
+        // Check $testPage is published, pre-deletion (getStatusFlags() returns empty array)
+        $this->assertTrue($testPage->getExistsOnLive());
+
+        $instance = new WorkflowInstance();
+        $instance->beginWorkflow($newDef2, $testPage);
+        $instance->execute();
+
+        // Now delete the related WorkflowDefinition and ensure status is the same
+        // (i.e. so it's not 'modified' for example)
+        $newDef2->delete();
+
+        // Check $testPage is _still_ published, post-deletion (getStatusFlags() returns empty array)
+        $this->assertTrue($testPage->getExistsOnLive());
+    }
 }


### PR DESCRIPTION
If the Page class doesn't exist, or is an abstract class, the tests fail.
If using the SiteTree (which always exists if the cms module is installed) they run as expected.
