### PR TITLE
Check there is a controller before requesting it

### DIFF
--- a/code/extensions/WorkflowEmbargoExpiryExtension.php
+++ b/code/extensions/WorkflowEmbargoExpiryExtension.php
@@ -510,7 +510,7 @@ class WorkflowEmbargoExpiryExtension extends DataExtension {
     public function getFutureTime()
     {
         $time = null;
-        $curr = Controller::curr();
+        $curr = Controller::has_curr() ? Controller::curr() : false;
 
         if ($curr) {
             $ft = $curr->getRequest()->getVar('ft');


### PR DESCRIPTION
Controller:curr() triggers a user_error if there is no current controller. Check there is a controller before trying to request it.
